### PR TITLE
Stable Particles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ PS C:\Users\gordo> uvx atlas-mc-scanner particles mc23_13p6TeV:mc23_13p6TeV.5612
 ╘══════════╧══════════════╧═════════╧═══════════════════╧═══════════════════╧═══════════════════╛
 ```
 
+And looking at the decay products:
+
+```bash
+$ atlas-mc-scanner decays mc23_13p6TeV:mc23_13p6TeV.561231.MGPy8EG_A14N23LO_HAHM_ggHZdZd_mumu_600_0p005.deriv.DAOD_LLP1.e8577_e8528_a934_s4370_r16083_r15970_p6619_tid42970882_00 13
+
+╒═══════════════════════════╤═══════════════╤═════════════╤════════════╕
+│ Decay Products (PDGIDs)   │ Decay Names   │   Frequency │ Fraction   │
+╞═══════════════════════════╪═══════════════╪═════════════╪════════════╡
+│ [13, 22]                  │ mu- + gamma   │        1438 │ 40.66%     │
+├───────────────────────────┼───────────────┼─────────────┼────────────┤
+│ [13]                      │ mu-           │        1373 │ 38.82%     │
+├───────────────────────────┼───────────────┼─────────────┼────────────┤
+│ No Decay Products         │               │         726 │ 20.53%     │
+╘═══════════════════════════╧═══════════════╧═════════════╧════════════╛
+```
+
+The ATLAS decay model is complex:
+
+- If the _Decay Products_ column contains `No Decay Products`, that means a decay vertex was found in the `TruthParticle`, but it had decay products.
+
 ### Commands
 
 - Use the `particles` sub-command to list a container of truth particles

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ $ atlas-mc-scanner decays mc23_13p6TeV:mc23_13p6TeV.561231.MGPy8EG_A14N23LO_HAHM
 The ATLAS decay model is complex:
 
 - If the _Decay Products_ column contains `No Decay Products`, that means a decay vertex was found in the `TruthParticle`, but it had decay products.
+- If the _Decay Products_ column contains `Stable`, that means no decay vertex was found.
 
 ### Commands
 

--- a/src/atlas_mc_scanner/cli.py
+++ b/src/atlas_mc_scanner/cli.py
@@ -43,7 +43,13 @@ def particles(
     execute_request(data_set_name, container)
 
 
-@app.command()
+@app.command(
+    epilog="""
+Note:
+
+    - `No Decay Products` means that a `TruthParticle` decay vertex was found, but it had no outgoing particles.
+"""
+)
 def decays(
     data_set_name: str = typer.Argument(..., help="RUCIO dataset name"),
     particle_name: str = typer.Argument(
@@ -63,7 +69,7 @@ def decays(
         help="Increase verbosity (-v for INFO, -vv for DEBUG)",
     ),
 ):
-    """print out decay frequency for a particular particle"""
+    """Print out decay frequency for a particular particle."""
     set_verbosity(verbose)
     from atlas_mc_scanner.decays import execute_decay
 

--- a/src/atlas_mc_scanner/cli.py
+++ b/src/atlas_mc_scanner/cli.py
@@ -48,6 +48,8 @@ def particles(
 Note:
 
     - `No Decay Products` means that a `TruthParticle` decay vertex was found, but it had no outgoing particles.
+
+    - `Stable` means no decay vertex was found.
 """
 )
 def decays(

--- a/src/atlas_mc_scanner/cli.py
+++ b/src/atlas_mc_scanner/cli.py
@@ -35,12 +35,17 @@ def particles(
         count=True,
         help="Increase verbosity (-v for INFO, -vv for DEBUG)",
     ),
+    no_abs: bool = typer.Option(
+        False,
+        "--no-abs",
+        help="Do not take the absolute value of the pdgid before creating the table.",
+    ),
 ):
     """Dump particles in the dataset."""
     set_verbosity(verbose)
     from atlas_mc_scanner.list_particles import execute_request
 
-    execute_request(data_set_name, container)
+    execute_request(data_set_name, container, no_abs)
 
 
 @app.command(

--- a/src/atlas_mc_scanner/decays.py
+++ b/src/atlas_mc_scanner/decays.py
@@ -34,9 +34,9 @@ def query(pdgid: int, container_name="TruthBSMWithDecayParticles"):
         lambda e: {
             "decay_pdgId": [
                 [vp.pdgId() for vp in t.decayVtx().outgoingParticleLinks()]
-                for t in e.good
+                for t in e.good  # type: ignore
             ],
-            "none_count": e.none_count,
+            "none_count": e.none_count,  # type: ignore
         }
     )
 

--- a/src/atlas_mc_scanner/decays.py
+++ b/src/atlas_mc_scanner/decays.py
@@ -19,17 +19,24 @@ def query(pdgid: int, container_name="TruthBSMWithDecayParticles"):
     all_mc_particles = query_base.Select(
         lambda e: e.TruthParticles(container_name)
     ).Select(
-        lambda particles: particles.Where(lambda p: p.pdgId() == pdgid).Where(
-            lambda p: p.hasDecayVtx()
-        )
+        lambda particles: {
+            "good": particles.Where(lambda p: p.pdgId() == pdgid).Where(
+                lambda p: p.hasDecayVtx()
+            ),
+            "none_count": particles.Where(lambda p: p.pdgId() == pdgid)
+            .Where(lambda p: not p.hasDecayVtx())
+            .Count(),
+        }
     )
 
     # Next, fetch everything we want from them.
     result = all_mc_particles.Select(
         lambda e: {
             "decay_pdgId": [
-                [vp.pdgId() for vp in t.decayVtx().outgoingParticleLinks()] for t in e
-            ]
+                [vp.pdgId() for vp in t.decayVtx().outgoingParticleLinks()]
+                for t in e.good
+            ],
+            "none_count": e.none_count,
         }
     )
 
@@ -54,16 +61,14 @@ def execute_decay(
 
     # Run the query.
     q = query(pdgid, container_name)
-    result = run_query(q, data_set_name)["decay_pdgId"]
+    all_results = run_query(q, data_set_name)
+    result = all_results["decay_pdgId"]
+    none_count = all_results["none_count"]
 
     def as_tuple(np_decay):
         "Turn a list of integers into a tuple of integers"
         return tuple(int(a) for a in np_decay)
 
-    # Find all the unique decays. This is horribly slow, but it works.
-    # unique, counts = np.unique(
-    #     ak.flatten(result).to_numpy(), return_counts=True, axis=0
-    # )
     counts_dict = defaultdict(int)
     for decay in ak.flatten(result):
         decay_tuple = as_tuple(decay)
@@ -79,13 +84,24 @@ def execute_decay(
 
     # Print table of decay frequencies
 
-    total = sum(counts)
+    total_none_count = ak.sum(none_count)
+    total = sum(counts) + total_none_count
     table = []
     for decay, count in zip(unique, counts):
         decay_tuple = as_tuple(decay)
         fraction = count / total if total > 0 else 0
         decay_list = list(decay_tuple) if len(decay_tuple) > 0 else "No Decay Products"
         table.append([decay_list, decay_names[decay_tuple], count, f"{fraction:.2%}"])
+
+    if total_none_count > 0:
+        table.append(
+            [
+                "Stable",
+                "",
+                total_none_count,
+                f"{total_none_count / (total):.2%}",
+            ]
+        )
     table.sort(key=lambda row: float(row[3].strip("%")), reverse=True)
     print(
         tabulate(

--- a/src/atlas_mc_scanner/decays.py
+++ b/src/atlas_mc_scanner/decays.py
@@ -84,9 +84,8 @@ def execute_decay(
     for decay, count in zip(unique, counts):
         decay_tuple = as_tuple(decay)
         fraction = count / total if total > 0 else 0
-        table.append(
-            [list(decay_tuple), decay_names[decay_tuple], count, f"{fraction:.2%}"]
-        )
+        decay_list = list(decay_tuple) if len(decay_tuple) > 0 else "Stable"
+        table.append([decay_list, decay_names[decay_tuple], count, f"{fraction:.2%}"])
     table.sort(key=lambda row: float(row[3].strip("%")), reverse=True)
     print(
         tabulate(

--- a/src/atlas_mc_scanner/decays.py
+++ b/src/atlas_mc_scanner/decays.py
@@ -84,7 +84,7 @@ def execute_decay(
     for decay, count in zip(unique, counts):
         decay_tuple = as_tuple(decay)
         fraction = count / total if total > 0 else 0
-        decay_list = list(decay_tuple) if len(decay_tuple) > 0 else "Stable"
+        decay_list = list(decay_tuple) if len(decay_tuple) > 0 else "No Decay Products"
         table.append([decay_list, decay_names[decay_tuple], count, f"{fraction:.2%}"])
     table.sort(key=lambda row: float(row[3].strip("%")), reverse=True)
     print(

--- a/src/atlas_mc_scanner/list_particles.py
+++ b/src/atlas_mc_scanner/list_particles.py
@@ -19,14 +19,15 @@ def query(container_name="TruthBSMWithDecayParticles"):
     return result
 
 
-def execute_request(ds_name, container_name="TruthBSMWithDecayParticles"):
+def execute_request(ds_name, container_name="TruthBSMWithDecayParticles", no_abs=False):
     q = query(container_name)
     result = run_query(q, ds_name)
 
     # now, collate everything by particle id to get a count.
     total_events = len(result)
 
-    r = ak.flatten(abs(result.pdgid)).to_numpy()
+    pdgid_list = result.pdgid if no_abs else abs(result.pdgid)
+    r = ak.flatten(pdgid_list).to_numpy()
 
     unique, counts = np.unique(r, return_counts=True)
     pdgid_counts = dict(zip(unique, counts))

--- a/src/atlas_mc_scanner/list_particles.py
+++ b/src/atlas_mc_scanner/list_particles.py
@@ -49,7 +49,7 @@ def execute_request(ds_name, container_name="TruthBSMWithDecayParticles", no_abs
         )
         for pid, count in pdgid_counts.items()
     ]
-    table.sort(key=lambda x: x[2], reverse=True)
+    table.sort(key=lambda x: x[2], reverse=True)  # type: ignore
     print(
         tabulate(
             table,

--- a/src/atlas_mc_scanner/list_particles.py
+++ b/src/atlas_mc_scanner/list_particles.py
@@ -54,7 +54,7 @@ def execute_request(ds_name, container_name="TruthBSMWithDecayParticles", no_abs
         tabulate(
             table,
             headers=[
-                "PDG ID",
+                "PDG ID" if no_abs else "abs(PDG ID)",
                 "Name",
                 "Count",
                 "Avg Count/Event",


### PR DESCRIPTION
* Dump out decays that have no decay particles and no decay vertices
* Add a `--no-abs` to the `particles` command to dump the actual particle names rather than the abs of the PDGID.

Fixes #11
