### PR TITLE
Refactor execution helpers

### DIFF
--- a/src/atlas_mc_scanner/cli.py
+++ b/src/atlas_mc_scanner/cli.py
@@ -78,7 +78,8 @@ def particles(
     epilog="""
 Note:
 
-    - `No Decay Products` means that a `TruthParticle` decay vertex was found, but it had no outgoing particles.
+    - `No Decay Products` means that a `TruthParticle` decay vertex was found, but it had no
+       outgoing particles.
 
     - `Stable` means no decay vertex was found.
 """
@@ -115,12 +116,14 @@ def decays(
             decay_products = "No Decay Products"
         else:
             decay_products = list(s.pdgids)
-        table.append([
-            decay_products,
-            s.decay_names,
-            s.count,
-            f"{s.fraction:.2%}",
-        ])
+        table.append(
+            [
+                decay_products,
+                s.decay_names,
+                s.count,
+                f"{s.fraction:.2%}",
+            ]
+        )
     print(
         tabulate(
             table,

--- a/src/atlas_mc_scanner/find_containers.py
+++ b/src/atlas_mc_scanner/find_containers.py
@@ -1,9 +1,19 @@
-from servicex_analysis_utils import get_structure
+from dataclasses import dataclass
 import re
+from typing import List
+
+from servicex_analysis_utils import get_structure
 
 
-def execute_find_containers(data_set_name: str):
-    """Print containers that likely contain TruthParticles for the given dataset name."""
+@dataclass
+class ContainerInfo:
+    """Information about a container that likely holds TruthParticles."""
+
+    name: str
+
+
+def execute_find_containers(data_set_name: str) -> List[ContainerInfo]:
+    """Return containers that likely contain TruthParticles for the given dataset name."""
 
     data = get_structure(data_set_name, array_out=False)
     assert isinstance(data, str), "Expected data to be a string"
@@ -16,5 +26,4 @@ def execute_find_containers(data_set_name: str):
             container_names.append(match.group(1))
     # container_names now contains the parsed names, e.g., ['TruthBSM', ...]
 
-    for name in container_names:
-        print(name)
+    return [ContainerInfo(name=n) for n in container_names]

--- a/src/atlas_mc_scanner/find_containers.py
+++ b/src/atlas_mc_scanner/find_containers.py
@@ -26,4 +26,6 @@ def execute_find_containers(data_set_name: str) -> List[ContainerInfo]:
             container_names.append(match.group(1))
     # container_names now contains the parsed names, e.g., ['TruthBSM', ...]
 
-    return [ContainerInfo(name=n) for n in container_names]
+    return sorted(
+        [ContainerInfo(name=n) for n in container_names], key=lambda x: x.name
+    )


### PR DESCRIPTION
## Summary
- return dataclasses from executors instead of printing
- add table printing to CLI commands
- rename `execute_request` to `summarize_particles`
- Add sorting for container names from `find-containers`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686834f6a7048320a423c44310f4fb6f