### PR TITLE
Add tests for execution helpers

### DIFF
--- a/tests/test_decays.py
+++ b/tests/test_decays.py
@@ -1,0 +1,38 @@
+import awkward as ak
+
+from atlas_mc_scanner import decays, common
+
+
+def test_execute_decay(monkeypatch):
+    fake_data = ak.Array(
+        {
+            "decay_pdgId": [[[13, 22], [13]], [[]]],
+            "none_count": [0, 2],
+        }
+    )
+
+    monkeypatch.setattr(common, "deliver", lambda *a, **k: "dummy")
+    monkeypatch.setattr(common, "to_awk", lambda result: {"atlas-mc-scanner": fake_data})
+
+    monkeypatch.setattr(decays, "get_pdgid_from_name_or_int", lambda name: 13)
+    monkeypatch.setattr(
+        decays,
+        "get_particle_name",
+        lambda pid: {13: "mu-", 22: "gamma"}.get(pid, f"Unknown ({pid})"),
+    )
+
+    summaries = decays.execute_decay("rucio://scope:name", "13")
+
+    expected = [
+        decays.DecaySummary(pdgids=None, decay_names="", count=2, fraction=0.4),
+        decays.DecaySummary(
+            pdgids=(13, 22),
+            decay_names="mu- + gamma",
+            count=1,
+            fraction=0.2,
+        ),
+        decays.DecaySummary(pdgids=(13,), decay_names="mu-", count=1, fraction=0.2),
+        decays.DecaySummary(pdgids=tuple(), decay_names="", count=1, fraction=0.2),
+    ]
+
+    assert summaries == expected

--- a/tests/test_find_containers.py
+++ b/tests/test_find_containers.py
@@ -1,0 +1,20 @@
+from atlas_mc_scanner import find_containers
+
+
+def test_execute_find_containers(monkeypatch):
+    fake_output = "\n".join([
+        "fooAuxDyn.pdgId",
+        "something else",
+        "barAuxDyn.pdgId",
+    ])
+
+    monkeypatch.setattr(find_containers, "get_structure", lambda *a, **k: fake_output)
+
+    result = find_containers.execute_find_containers("dataset")
+
+    expected = [
+        find_containers.ContainerInfo(name="bar"),
+        find_containers.ContainerInfo(name="foo"),
+    ]
+
+    assert result == expected

--- a/tests/test_list_particles.py
+++ b/tests/test_list_particles.py
@@ -1,0 +1,39 @@
+import awkward as ak
+
+from atlas_mc_scanner import list_particles, common
+
+
+def test_summarize_particles(monkeypatch):
+    fake_data = ak.Array({"pdgid": [[13, 13], [22], []]})
+
+    monkeypatch.setattr(common, "deliver", lambda *a, **k: "dummy")
+    monkeypatch.setattr(common, "to_awk", lambda result: {"atlas-mc-scanner": fake_data})
+
+    monkeypatch.setattr(
+        list_particles,
+        "get_particle_name",
+        lambda pid: {13: "mu-", 22: "gamma"}.get(pid, f"Unknown ({pid})"),
+    )
+
+    summaries = list_particles.summarize_particles("rucio://scope:name")
+
+    expected = [
+        list_particles.ParticleSummary(
+            pdgid=13,
+            name="mu-",
+            count=2,
+            avg_per_event=2 / 3,
+            max_per_event=2,
+            min_per_event=0,
+        ),
+        list_particles.ParticleSummary(
+            pdgid=22,
+            name="gamma",
+            count=1,
+            avg_per_event=1 / 3,
+            max_per_event=1,
+            min_per_event=0,
+        ),
+    ]
+
+    assert summaries == expected


### PR DESCRIPTION
## Summary
- add tests for `execute_decay`, `execute_find_containers` and `summarize_particles`
- mock ServiceX interactions for offline testing

## Testing
- `pytest -q`

Fixes #32

------
https://chatgpt.com/codex/tasks/task_e_68684eed73c08320a55e1865b43e2733